### PR TITLE
chore: update portal version to v2.2.0

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/server": "^4.10.4",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/portal/package-lock.json
+++ b/apps/portal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portal",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portal",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@angular/animations": "^17.3.6",
         "@angular/common": "^17.3.6",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
Updated the api and app version from 2.1.0 to 2.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `api` app to 2.2.0.
	- Updated the version of the `portal` app to 2.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->