### PR TITLE
build: migrate to docker compose v2

### DIFF
--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   transcript-summarizer-api:
     image: transcript-summarizer-api

--- a/apps/api/docs/production-setup.md
+++ b/apps/api/docs/production-setup.md
@@ -49,7 +49,7 @@ Make sure Redis and MariaDB server are up and running.
    GPT_MODEL="gpt-4o"
 
    # Docker env
-   COMPOSE_PROJECT_NAME=transcript-summarizer-api 
+   COMPOSE_PROJECT_NAME=transcript-summarizer-api
    ```
 
 Make sure to replace the above example values with appropriate values as per your setup and configuration. Server Port is `3000`, you can update it if you want to use a different port of your choice.
@@ -114,7 +114,7 @@ Before using Docker, ensure you've configured the environment variables in your 
 **Step 2: Build your docker container**
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 **Step 3: Start the Docker Containers**
@@ -122,7 +122,7 @@ docker-compose build
 To start your application within Docker containers, run the following command:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 **Step 4: Database Migrations (First-Time Setup)**
@@ -142,19 +142,19 @@ If you need to update any environment variable values:
 2. Stop the running containers:
 
    ```bash
-   docker-compose down
+   docker compose down
    ```
 
 3. Rebuild the Docker containers with the updated environment variables:
 
    ```bash
-   docker-compose build
+   docker compose build
    ```
 
 4. Start the Docker containers again:
 
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 With these steps, your application should be up and running in Docker with the updated environment variables.

--- a/apps/api/docs/usage-guide.md
+++ b/apps/api/docs/usage-guide.md
@@ -34,10 +34,10 @@ Users must have a valid **Microsoft account** for **Azure Authentication**. Ensu
 Follow the development setup guides for API and portal to set up the codebase before proceeding further:
 
 1. Set up API:
-   - [API Development setup](/docs/development-setup.md)
-   - [API Production setup](/docs/production-setup.md)
+   - [API Development setup](./development-setup.md)
+   - [API Production setup](./production-setup.md)
 2. Set up Portal:
-   - [Portal Development setup](/../portal/docs/development-setup.md)
+   - [Portal Development setup](../../portal/docs/development-setup.md)
 
 ## 3. Using the Transcript Summarizer Portal
 


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[REST-1421](https://pinestem.com/dashboard.html#/tasks/REST-1421/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary unit testing.
- [x] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/TranscriptSummarizer.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

- Migrate to docker compose v2 standards for repository
- Remove deprecated `version` keyword
- Update documentation with docker compose v2 commands

**Additional notes:**

- https://docs.docker.com/reference/compose-file/version-and-name/
- https://docs.docker.com/compose/releases/migrate/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated all Docker CLI commands to use the modern `docker compose` syntax instead of the deprecated `docker-compose`.
  - Removed a trailing space from the example environment variable in the documentation.
  - Corrected relative links in setup guides for improved navigation.

- **Chores**
  - Removed the version declaration line from the Docker Compose configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->