### PR TITLE
fix: update docker-compose retry policy to unless-stopped

### DIFF
--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   transcript-summarizer-mariadb:
     container_name: transcript-summarizer-mariadb
     image: mariadb:latest
-    restart: always
+    restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_USER: ${DB_USERNAME}
@@ -31,7 +31,7 @@ services:
   transcript-summarizer-redis:
     container_name: transcript-summarizer-redis
     image: redis:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - '127.0.0.1:${REDIS_DOCKER_PORT}:6379'
 


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-1545](https://pinestem.com/dashboard.html#/tasks/REST-1545/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Update retry policy to unless-stopped for all docker-compose services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the restart policy for database and cache services to improve container management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->